### PR TITLE
🐛 Fix: Properly fail workflow when validation fails

### DIFF
--- a/.github/workflows/pr-complete.yml
+++ b/.github/workflows/pr-complete.yml
@@ -34,16 +34,18 @@ jobs:
       # Step 1: Validate the YAML
       - name: Validate terms
         id: validate
-        continue-on-error: true
+        #continue-on-error: true
         run: |
           node scripts/validateTerms.js 2>&1 | tee validation-output.txt
-          echo "valid=$?" >> $GITHUB_OUTPUT
+          VALIDATION_EXIT_CODE=${PIPESTATUS[0]}
+          echo "valid=$VALIDATION_EXIT_CODE" >> $GITHUB_OUTPUT
           {
             echo 'validation_output<<EOF'
             cat validation-output.txt
             echo EOF
           } >> $GITHUB_OUTPUT
-      
+          exit $VALIDATION_EXIT_CODE
+
       # Step 2: Score if valid
       - name: Score terms
         id: score


### PR DESCRIPTION
- Remove continue-on-error to stop workflow on validation failure
- Capture actual validation exit code using PIPESTATUS
- Exit with validation code to properly fail the workflow
- Prevents invalid terms from being merged

<!-- 
Create this file at: .github/pull_request_template.md
This template appears automatically when someone creates a PR (CLI and some UIs)
-->

## 🎮 New Term Submission

### The Term I'm Adding:
**Term:** (type your term here)

**Score Goal:** (e.g., 70–100)

### Checklist:
- [ ] I've added my term to `terms.yaml`
- [ ] I've included a definition
- [ ] I've added humor (going for those 30 bonus points!)
- [ ] I've checked my YAML syntax
- [ ] I'm ready to get roasted... I mean, scored!

### Why This Term Matters:
(Write 1–3 sentences explaining why this term should be included.)

### My Humor Attempt:
(Write your humor/joke line here.)

---
*Automation will score this PR in ~30 seconds. Good luck! 🎲*