### PR TITLE
Add promotional campaign plan for FOSS Glossary

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Every term is scored out of 100 points:
 - **🔥 Flame Warrior** - Document controversial topics
 - **📜 Historian** - Add historical context
 
+## 📣 Promote the Project
+
+Want to help spread the word? Check out the [FOSS Glossary Promotional Campaign](docs/promoting-campaign.md) for a 90-day plan covering content ideas, outreach channels, and success metrics.
+
 ## Example Term
 ```yaml
 - term: "Git"

--- a/docs/promoting-campaign.md
+++ b/docs/promoting-campaign.md
@@ -1,0 +1,89 @@
+# FOSS Glossary Promotional Campaign
+
+## 1. Campaign Overview
+- **Objective:** Grow awareness of the FOSS Glossary, attract new contributors, and drive visits to the docs site.
+- **Core Message:** "Decode FOSS culture with humor, learn faster, and contribute your own terms."
+- **Success Metrics:**
+  - +30% unique visitors to the docs site in 90 days
+  - 20 new glossary term contributions
+  - 200 new stars or watches on GitHub
+  - 3 collaborations with community partners (podcasts, newsletters, or blogs)
+
+## 2. Audience Segments
+1. **Newcomers to Open Source** – people searching for quick explanations of OSS jargon.
+2. **Maintainers & Contributors** – communities who can add terms and share glossary with their audiences.
+3. **Educators & Trainers** – bootcamps, CS instructors, and meetup organizers looking for teaching resources.
+4. **Tech Humor Communities** – meme accounts, developer newsletters, and podcasts that appreciate witty content.
+
+## 3. Brand Voice & Creative
+- **Tone:** Playful, witty, inclusive, but informative.
+- **Visuals:** Leverage existing assets (logo, glossary cards). Use bold colors, monospace snippets, and emoji callouts.
+- **CTA Examples:**
+  - "Learn the lingo. Laugh along. Contribute a term!"
+  - "Got a spicy OSS story? Turn it into glossary gold."
+  - "Translate FOSS jargon for your community—fork and contribute."
+
+## 4. Key Campaign Pillars
+1. **Educational Content:** Publish term spotlights, explainers, and "Why it matters" posts.
+2. **Community Challenges:** Run themed sprints (e.g., "Governance Month", "Debugging Disasters Week").
+3. **Humor Hooks:** Share quotable jokes from glossary entries; invite community to vote on funniest term.
+4. **Contributor Recognition:** Shout-outs on social, badges in repo, highlight interviews with top contributors.
+
+## 5. Content & Asset Plan
+| Asset | Description | Owner | Frequency |
+| --- | --- | --- | --- |
+| Blog/Medium Posts | Deep dives into 3-5 glossary terms with real-world stories | Core maintainers | Monthly |
+| Twitter/Bluesky Threads | Bite-sized terms + humor snippet + CTA | Social volunteer | 2x weekly |
+| LinkedIn Posts | Professional angle: how FOSS Glossary helps onboarding | Maintainer | Weekly |
+| Short Videos/Reels | 30-45 sec "term explainers" with humor overlays | Community creator | Bi-weekly |
+| Docs Site Updates | Feature campaign highlights & call to contribute | Docs maintainer | Monthly |
+| Newsletter Blurb | 150-word highlight for partner newsletters | Outreach lead | Monthly |
+
+## 6. Distribution Channels
+- **Owned**: GitHub repo, docs site, project newsletter (create signup form using GitHub Pages), official social accounts.
+- **Earned**: Post in r/opensource, Lobsters, Hacker News "Show HN", dev.to, Hashnode, Indie Hackers.
+- **Shared**: OSS Slack/Discord communities (CHAOSS, SustainOSS, OSPO Alliance), Mastodon (#FOSS, #OpenSource), LinkedIn groups.
+- **Paid/Boosted (optional)**: Sponsor OSS-friendly newsletters (e.g., Console, TLDR) for one-off features if budget permits.
+
+## 7. Campaign Timeline (90 Days)
+1. **Weeks 1-2 – Setup**
+   - Finalize assets, update README with CTA, schedule first month of social posts, prepare press kit.
+   - Collect testimonials/quotes from early contributors.
+2. **Weeks 3-6 – Launch Burst**
+   - Publish launch blog post, share across channels, pitch to newsletters.
+   - Run first "Term Sprint" challenge (e.g., licensing jargon) with leaderboard.
+   - Host a live stream or Twitter Space about humorous OSS stories.
+3. **Weeks 7-10 – Sustain & Collaborate**
+   - Feature community-created content, cross-post to partner communities.
+   - Run meme contest and highlight top glossary terms weekly.
+4. **Weeks 11-13 – Showcase & Retain**
+   - Publish recap infographic (growth metrics, funniest submissions).
+   - Plan follow-up campaign or ongoing contributor program.
+
+## 8. Community Engagement Tactics
+- Create a "Contributor Spotlight" issue template to collect bios and quotes.
+- Launch "Glossary Term of the Week" pinned discussion.
+- Set up GitHub Discussions for suggestions and brainstorming.
+- Offer digital badges (PNG/SVG) for contributors to share on social profiles.
+- Encourage localization: invite translations and set up `i18n` label in issues.
+
+## 9. Partnerships & Outreach
+- Reach out to maintainers of documentation-focused tools (Docsify, MkDocs) for cross-promo.
+- Collaborate with education programs (The Odin Project, freeCodeCamp) for resource inclusion.
+- Pitch lightning talks at OSS conferences or virtual meetups (CHAOSScon, FOSDEM devrooms).
+- Provide media kit (logo, sample terms, project overview) for press coverage.
+
+## 10. Measurement & Iteration
+- Track analytics: GitHub Insights, GitHub Pages (use Plausible or GoatCounter), social analytics.
+- Monitor contributions using issues labeled `campaign-2024`.
+- Survey new contributors after PR merge for feedback.
+- Review metrics bi-weekly and adjust content cadence or messaging.
+
+## 11. Next Steps Checklist
+- [ ] Add campaign CTA to README and docs home page.
+- [ ] Prepare social media calendar for first month.
+- [ ] Draft launch blog post and newsletter blurb.
+- [ ] Create community challenge template issue.
+- [ ] Set up analytics dashboard and sharing workflow.
+
+*Last updated: 2025-10-10*


### PR DESCRIPTION
## Summary
- add a comprehensive 90-day promotional campaign plan covering goals, audiences, messaging, channels, and metrics
- surface the new campaign plan from the README to help contributors find outreach guidance

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e9437c0eec832682263289ff4ba020