### PR TITLE
Validation: enforce strict schema and export guard

### DIFF
--- a/.github/workflows/pr-complete.yml
+++ b/.github/workflows/pr-complete.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: '20'
       
       - name: Install dependencies
-        run: npm install js-yaml
+        run: npm ci --include=dev --no-audit --no-fund
       
       # Step 1: Validate the YAML
       - name: Validate terms
@@ -59,7 +59,7 @@ jobs:
       # Step 3: Get PR statistics
       - name: Get glossary stats
         id: stats
-        if: always()
+        if: steps.validate.outputs.valid == '0'
         run: |
           node -e "
           const fs = require('fs');

--- a/.github/workflows/update-landing-page.yml
+++ b/.github/workflows/update-landing-page.yml
@@ -63,7 +63,13 @@ jobs:
       # Export terms.json only if new terms were added.
       # This runs after landing page generation to ensure the exported terms reflect the latest updates.
       - name: Export terms.json (only if new terms)
-        run: node scripts/exportTerms.js --only-if-new
+        run: |
+          npm run export:new
+          if [ -f docs/terms.json ]; then
+            echo "terms.json updated"
+          else
+            echo "ℹ️ No docs/terms.json generated (no new terms)"
+          fi
 
       - name: Add and commit changes
         run: |

--- a/schema.json
+++ b/schema.json
@@ -2,19 +2,30 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "FOSS Glossary Terms",
   "type": "object",
+  "required": ["terms"],
+  "additionalProperties": false,
   "properties": {
     "terms": {
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["term", "definition"],
+        "required": ["slug", "term", "definition"],
+        "additionalProperties": false,
         "properties": {
+          "slug": {
+            "type": "string",
+            "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+            "minLength": 3,
+            "maxLength": 48,
+            "description": "Stable identifier for the glossary term"
+          },
           "term": {
             "type": "string",
             "description": "The FOSS term being defined"
           },
           "definition": {
             "type": "string",
+            "minLength": 80,
             "description": "Short, clear definition"
           },
           "explanation": {
@@ -34,6 +45,11 @@
             "type": "array",
             "items": { "type": "string" },
             "description": "Categories"
+          },
+          "aliases": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Alternate labels for this term"
           },
           "controversy_level": {
             "type": "string",

--- a/terms.yaml
+++ b/terms.yaml
@@ -1,197 +1,225 @@
 # FOSS Glossary - Community-driven definitions
 terms:
-  - term: "RTFM"
-    definition: "Read The F***ing Manual"
+  - slug: rtfm
+    term: "RTFM"
+    definition: "Read The F***ing Manual — a blunt reminder to consult documentation before asking questions so helpers aren't repeating themselves."
     explanation: "A gentle reminder to check the documentation before asking questions"
     humor: "The four most powerful letters in tech support, capable of solving 90% of problems and hurting 100% of feelings"
     tags: ["acronym", "documentation", "support"]
     see_also: ["LMGTFY", "PEBKAC"]
     
-  - term: "Yak Shaving"
-    definition: "Doing a series of seemingly unrelated tasks before you can do what you actually intended"
+  - slug: yak-shaving
+    term: "Yak Shaving"
+    definition: "Doing a series of seemingly unrelated tasks before you can do what you actually intended because each prerequisite reveals yet another detour."
     explanation: "You start trying to fix a bug, and somehow end up updating your entire OS"
     humor: "I came here to write code, and somehow I'm now learning about Tibetan yak grooming techniques"
     tags: ["productivity", "procrastination"]
     
-  - term: "FOSS"
-    definition: "Free and Open Source Software"
+  - slug: foss
+    term: "FOSS"
+    definition: "Free and Open Source Software that guarantees users the freedom to run, study, modify, and share code without restrictive licensing."
     explanation: "Software that's free as in freedom AND free as in beer"
     humor: "Where programmers work for free to make software that companies will use to make millions"
     tags: ["acronym", "philosophy", "licensing"]
     see_also: ["GPL", "MIT License", "Copyleft"]
 
-  - term: "Bus Factor"
-    definition: "The number of team members that can be hit by a bus before a project fails"
+  - slug: bus-factor
+    term: "Bus Factor"
+    definition: "The number of team members that can be hit by a bus before a project fails, highlighting how fragile knowledge sharing becomes when only a few people hold critical context."
     explanation: "A metric that measures how many developers need to suddenly disappear before a project can no longer continue. A bus factor of 1 means the project relies on a single person - extremely risky!"
     humor: "Also known as the 'lottery factor' for optimists who prefer their team members winning millions over getting flattened. Some companies have tried improving their bus factor by banning employees from traveling together, which rather misses the point."
     tags: ["project-management", "risk", "metrics", "dark-humor"]
     see_also: ["Single Point of Failure", "Documentation", "Knowledge Silo"]
     controversy_level: "low"
 
-  - term: "Dependency Hell"
-    definition: "A situation where software dependencies become so tangled, outdated, or incompatible that progress grinds to a halt"
+  - slug: dependency-hell
+    term: "Dependency Hell"
+    definition: "A situation where software dependencies become so tangled, outdated, or incompatible that progress grinds to a halt because every attempted upgrade introduces new conflicts."
     explanation: "You try to install a package, but it needs a newer version of another package, which conflicts with a third package, which depends on a deprecated library that only works on an older OS you no longer have. Every fix breaks something else."
     humor: "Like a soap opera for code: everyone’s connected, nobody’s happy, and you’re stuck watching the drama unfold while your build fails."
     tags: ["package-management", "frustration", "software-maintenance"]
     see_also: ["Version Pinning", "DLL Hell", "Semantic Versioning"]
     controversy_level: "medium"
 
-  - term: "License Proliferation"
-    definition: "The overabundance of open source licenses, often with subtle but significant differences, making it difficult to combine or reuse code across projects."
+  - slug: license-proliferation
+    term: "License Proliferation"
+    definition: "The overabundance of open source licenses, often with subtle but significant differences, making it difficult to combine or reuse code across projects without legal contortions."
     explanation: "You find a great library under GPL, another under Apache, and a third under MPL. Each has slightly different requirements about attribution, distribution, or linking. Suddenly, your 'simple' project feels like you need a law degree just to ship a prototype."
     humor: "Like trying to host a potluck where everyone insists on bringing food—but only if you agree to eat it under their very specific house rules."
     tags: ["open-source", "legal", "compatibility", "community"]
     see_also: ["GPL", "MIT License", "Copyleft", "License Compatibility"]
     controversy_level: "high"
 
-  - term: "Code Hoarding"
-    definition: "The tendency to accumulate large amounts of code, libraries, or tools—often unused—under the belief they might be useful someday."
+  - slug: code-hoarding
+    term: "Code Hoarding"
+    definition: "The tendency to accumulate large amounts of code, libraries, or tools—often unused—under the belief they might be useful someday, even when they add clutter and maintenance overhead."
     explanation: "You clone dozens of GitHub repos, bookmark obscure CLI tools, and write half-finished scripts for problems you haven’t encountered yet. Your project folder resembles a digital attic more than a workspace."
     humor: "Like stocking up on canned beans for a zombie apocalypse that never comes—except the beans are Python scripts and the zombies are edge cases."
     tags: ["developer-habits", "tooling", "overengineering", "FOMO"]
     see_also: ["Overengineering", "Not Invented Here", "Premature Optimization"]
     controversy_level: "low"
 
-  - term: "Zombie Dependencies"
-    definition: "Outdated or abandoned libraries that are still widely used, often without active maintenance or clear alternatives."
+  - slug: zombie-dependencies
+    term: "Zombie Dependencies"
+    definition: "Outdated or abandoned libraries that are still widely used, often without active maintenance or clear alternatives, lurking silently until a breaking change or CVE emerges."
     explanation: "You build your app on a popular framework, only to discover one of its core dependencies hasn’t been updated in five years. The maintainer is unreachable, the issues pile up, and you're left wondering whether to fork it or flee."
     humor: "Like relying on a haunted vending machine — it still dispenses snacks, but nobody knows how or why it’s still running."
     tags: ["dependencies", "maintenance", "technical-debt", "risk"]
     see_also: ["Dependency Hell", "Forking", "Maintainer Burnout"]
     controversy_level: "medium"
 
-  - term: "Maintainer Burnout"
-    definition: "The exhaustion and disengagement experienced by open source maintainers who face constant demands, limited support, and little recognition."
+  - slug: maintainer-burnout
+    term: "Maintainer Burnout"
+    definition: "The exhaustion and disengagement experienced by open source maintainers who face constant demands, limited support, and little recognition from the communities relying on them."
     explanation: "A project gains popularity, issues and pull requests flood in, and suddenly the maintainer is expected to provide free tech support, security patches, and feature development around the clock. Without backup or funding, enthusiasm turns into fatigue."
     humor: "Like being the only bartender at a never-ending party where everyone wants a custom cocktail, but nobody tips."
     tags: ["community", "sustainability", "mental-health", "open-source"]
     see_also: ["Bus Factor", "Abandonware", "Forking"]
     controversy_level: "high"
 
-  - term: "Linus's Law"
-    definition: "The idea that 'given enough eyeballs, all bugs are shallow' — meaning open collaboration makes problems easier to find and fix."
+  - slug: linuss-law
+    term: "Linus's Law"
+    definition: "The idea that 'given enough eyeballs, all bugs are shallow' — suggesting open collaboration makes problems easier to find and fix because more reviewers share the workload."
     explanation: "When many developers review and use the same code, issues are more likely to be spotted quickly."
     humor: "Like having a hundred proofreaders for your essay — someone will catch that typo."
     tags: ["open-source", "collaboration", "quality"]
     see_also: ["Many Eyes Principle", "Peer Review", "Transparency"]
     controversy_level: "low"
 
-  - term: "Not Invented Here Syndrome"
-    definition: "A reluctance to adopt existing external solutions, leading teams to reimplement functionality themselves—even when mature, well-tested options already exist."
+  - slug: not-invented-here-syndrome
+    term: "Not Invented Here Syndrome"
+    definition: "A reluctance to adopt existing external solutions, leading teams to reimplement functionality themselves—even when mature, well-tested options already exist and would save effort."
     explanation: "Instead of using a popular open source library that solves the problem, a team decides to build their own version from scratch. The result is often duplicated effort, more bugs, and wasted time maintaining something that already had a community solution."
     humor: "Like refusing to buy bread because you’re convinced you can grow the wheat, mill the flour, and bake a better loaf in your spare time."
     tags: ["reinvention", "ego", "duplication", "engineering-culture"]
     see_also: ["Reinventing the Wheel", "Overengineering", "Code Hoarding"]
     controversy_level: "medium"
 
-  - term: "Code Rot"
-    definition: "The gradual decline in a codebase’s quality and maintainability over time, even without active changes."
+  - slug: code-rot
+    term: "Code Rot"
+    definition: "The gradual decline in a codebase’s quality and maintainability over time, even without active changes, as dependencies, environments, and expectations move on."
     explanation: "As dependencies evolve, environments shift, and original authors move on, code that once worked perfectly can become brittle, outdated, or incompatible. Left unchecked, code rot makes systems harder to maintain, more bug-prone, and resistant to new features."
     humor: "Like leaving a sandwich in the fridge for six months—technically it’s still there, but you probably don’t want to touch it."
     tags: [" maintenance", "technical-debt", "software-aging", "fragility"]
     see_also: ["Bit Rot", "Technical Debt", "Legacy Code"]
     controversy_level: "low"
     
-  - term: "Copyleft"
-    definition: "A licensing principle that requires derivative works to be distributed under the same license as the original."
+  - slug: copyleft
+    term: "Copyleft"
+    definition: "A licensing principle that requires derivative works to be distributed under the same license as the original so downstream users retain the same freedoms to modify and share."
     explanation: "Coined by Richard Stallman, 'copyleft' flips the idea of copyright on its head. Instead of restricting sharing, it ensures that freedoms to use, modify, and redistribute software are preserved in all future versions. The GNU General Public License (GPL) is the most famous example of a copyleft license. This principle is central to many FOSS projects because it guarantees that improvements remain free and open for the community."
     humor: "Think of it as copyright’s rebellious cousin who insists on sharing the family recipes with everyone at the potluck."
     tags: ["licensing", "FOSS", "GPL", "freedom"]
     see_also: ["Permissive License", "GNU General Public License", "Free Software"]
     controversy_level: "high"
 
-  - term: "Ship It"
-    definition: "Deploy to production and hope for the best"
+  - slug: ship-it
+    term: "Ship It"
+    definition: "Deploy to production and hope for the best, often uttered at the last minute when deadlines trump testing discipline and everyone crosses their fingers."
     humor: "What you say at 4:59 PM on a Friday"
     tags: ["deployment", "courage"]
  
-  - term: "YOLO Deploy"
-    definition: "Deploying directly to production without testing"
+  - slug: yolo-deploy
+    term: "YOLO Deploy"
+    definition: "Deploying directly to production without testing because confidence or impatience overrides caution, usually followed by frantic monitoring."
     humor: "Your Ops team Loves Organization... just kidding"
     tags: ["deployment", "chaos"]
 
-  - term: "Works on My Machine"
-    definition: "The developer's eternal defense when code fails in production"
+  - slug: works-on-my-machine
+    term: "Works on My Machine"
+    definition: "The developer's eternal defense when code fails in production, implying the environment is to blame and quietly shifting responsibility back to operations."
     humor: "Certification program coming soon: WOMM Certified Developer™"
     tags: ["debugging", "classic", "excuse"]
 
-  - term: "Fork"
-    definition: "When developers copy an open-source project’s codebase to start their own version — sometimes to innovate, sometimes to escape endless mailing list debates"
+  - slug: fork
+    term: "Fork"
+    definition: "When developers copy an open-source project’s codebase to start their own version—sometimes to innovate, sometimes to escape endless mailing list debates and governance stalemates."
     humor: "Warning: excessive forking may lead to family drama in the GitHub tree"
     tags: ["FOSS", "open-source", "git", "community"]
 
-  - term: "Linux"
-    definition: "An open-source operating system kernel"
+  - slug: linux
+    term: "Linux"
+    definition: "An open-source operating system kernel that powers servers, desktops, smartphones, and countless embedded devices through collaborative development."
     explanation: "Forms the foundation of countless operating systems, powering everything from servers and smartphones to IoT devices"
     humor: "The only kernel that makes you feel powerful—until you realize you’ve spent three hours compiling drivers just to get your Wi-Fi working"
     tags: ["os", "kernel", "foss"]
     see_also: ["GNU", "Ubuntu", "Debian"]
 
-  - term: "PTW"
-    definition: "Patches Welcome"
+  - slug: ptw
+    term: "PTW"
+    definition: "Patches Welcome — a standard open-source response inviting contributors to submit code if they want a change, reminding requesters that collaboration beats complaints."
     explanation: "A common open‑source response meaning: if you want a feature or fix, contribute the code yourself."
     humor: "The polite way of saying: 'Yes, that’s a problem. No, I’m not fixing it for you.'"
     tags: ["FOSS", "contribution", "community", "development"]
     see_also: ["RTFS", "WONTFIX", "scratch-your-own-itch"]
 
-  - term: "WONTFIX"
-    definition: "Will Not Fix"
+  - slug: wontfix
+    term: "WONTFIX"
+    definition: "Will Not Fix — an issue tracker resolution meaning the reported bug or feature request will remain unresolved, often due to scope, philosophy, or maintenance trade-offs."
     explanation: "A resolution tag in issue trackers indicating that a reported bug or feature request will not be addressed, often due to philosophy, scope, or maintainability concerns."
     humor: "The open‑source equivalent of 'working as intended' — even when it clearly isn’t."
     tags: ["FOSS", "issue-tracking", "development", "community"]
     see_also: ["PTW", "RTFS", "scratch-your-own-itch"]
 
-  - term: "Dependency Drift"
-    definition: "The gradual divergence of a project's dependencies from their intended stable versions"
+  - slug: dependency-drift
+    term: "Dependency Drift"
+    definition: "The gradual divergence of a project's dependencies from their intended stable versions as packages update faster than the project’s maintenance cadence."
     explanation: "Happens when libraries and packages update faster than the project’s maintenance cycle, creating hidden technical debt and potential security gaps"
     humor: "Like waking up to find your roommates have all moved out and been replaced by strangers who insist they live there now"
     tags: ["foss", "maintenance", "technical-debt"]
     see_also: ["Version Pinning", "Semantic Versioning", "Supply Chain Security"]
 
-  - term: "LGTM"
-    definition: "Looks Good To Me"
+  - slug: lgtm
+    term: "LGTM"
+    definition: "Looks Good To Me — the classic approval signal in code reviews indicating the reviewer saw nothing alarming enough to block the change."
     explanation: "The standard approval comment in code reviews, indicating the reviewer has no major objections to the changes"
     humor: "Translation: I skimmed this for 30 seconds and didn't see anything on fire. Ship it!"
     tags: ["code-review", "approval", "acronym", "FOSS"]
     see_also: ["It's a Feature", "Works On My Machine"]
     
-  - term: "It's a Feature"
-    definition: "The art of rebranding a bug so profound and inexplicable that fixing it would break the universe"
+  - slug: its-a-feature
+    term: "It's a Feature"
+    definition: "The art of rebranding a bug so profound and inexplicable that fixing it would break the universe, so teams frame it as intentional behavior."
     explanation: "When a bug becomes so deeply integrated into user workflows that fixing it would cause more problems than it solves, so it gets documented as intentional behavior"
     humor: "Not a bug, it's a surprise mechanic for enhanced user engagement"
     tags: ["classic", "excuse", "documentation", "meme","FOSS"]
     see_also: ["LGTM", "Fork"]
 
-  - term: "Forkprint"
-    definition: "The unique trail of decisions, patches, and governance quirks that a forked project leaves behind"
+  - slug: forkprint
+    term: "Forkprint"
+    definition: "The unique trail of decisions, patches, and governance quirks that a forked project leaves behind, visible in commit history, contributor rosters, and release cadence."
     explanation: "Acts like a fingerprint, encoded in commit history, issue labels, and repo conventions"
     humor: "Proof that every fork thinks it's the chosen one, until you diff the forkprint and see the chaos"
     tags: ["governance", "identity", "traceability"]
     see_also: ["Git", "Fork", "Merge"]
 
-  - term: "Mergequake"
-    definition: "The sudden cascade of conflicts triggered when multiple long-lived branches are merged at once"
+  - slug: mergequake
+    term: "Mergequake"
+    definition: "The sudden cascade of conflicts triggered when multiple long-lived branches are merged at once, shaking the repo like tectonic plates colliding."
     explanation: "Happens when parallel work streams collide, shaking the repo like tectonic plates under stress"
     humor: "One minute you're merging, the next you're an amateur seismologist mapping aftershocks in rebase hell"
     tags: ["merge", "conflict", "workflow"]
     see_also: ["Rebase", "Forkprint", "Hotfix"]
 
-  - term: "Commitfog"
-    definition: "The haze of unclear commit messages that obscures project history"
+  - slug: commitfog
+    term: "Commitfog"
+    definition: "The haze of unclear commit messages that obscures project history and forces future maintainers to guess at intent during audits or rollbacks."
     explanation: "Occurs when developers push changes with vague or cryptic messages, making audits and rollbacks painful"
     humor: "Like trying to navigate with a map drawn in crayon during a blackout"
     tags: ["commits", "history", "anti-pattern"]  
     see_also: ["Changelog", "Forkprint", "Mergequake"]
 
-  - term: "Pullpocalypse"
-    definition: "The overwhelming flood of open pull requests that threatens to drown maintainers"
+  - slug: pullpocalypse
+    term: "Pullpocalypse"
+    definition: "The overwhelming flood of open pull requests that threatens to drown maintainers, creating backlog, merge conflicts, and frustrated contributors."
     explanation: "Occurs when contributors open more pull requests than the project team can reasonably review or merge, leading to backlog, merge conflicts, and contributor frustration"
     humor: "Like trying to bail out a sinking ship with a coffee mug during a thunderstorm"
     tags: ["pull requests", "maintenance", "overload", "anti-pattern"]
     see_also: ["Issue Avalanche", "Yakstack", "Commitfog"]
 
-  - term: "PEBKAC"
-    definition: "Problem Exists Between Keyboard And Chair"
+  - slug: pebkac
+    term: "PEBKAC"
+    definition: "Problem Exists Between Keyboard And Chair — a tongue-in-cheek acknowledgment that user error, not software flaws, caused the reported issue."
     explanation: "A humorous way to say the issue is due to user error rather than the system or software."
     humor: "A timeless classic in tech support — polite sarcasm wrapped in an acronym."
     tags: ["acronym", "support", "user-error"]


### PR DESCRIPTION
## Summary
- enforce slug, length, and property requirements for glossary terms
- fail validation on schema violations or normalized duplicates before scoring
- run `npm run export:new` in the landing workflow so docs/terms.json updates only when new terms land

## Files Modified
- schema.json
- scripts/validateTerms.js
- terms.yaml
- .github/workflows/pr-complete.yml
- .github/workflows/update-landing-page.yml

## Checklist
- [x] Root requires `terms` and forbids additional properties
- [x] Validator exits non-zero on schema failures or duplicates
- [x] Score and stats jobs run only after successful validation
- [x] Landing workflow regenerates docs/terms.json via `npm run export:new` when new terms are added

## Negative Test Plan
- inside-array junk → schema rejects non-object entries in `terms`
- top-level junk → schema blocks unknown root keys
- bad slug → schema fails invalid slug formats
- short definition → schema enforces minimum 80 characters
- duplicate via alias → validator detects normalized duplicates across names

Fixes #<ISSUE_NUMBER>

------
https://chatgpt.com/codex/tasks/task_e_68f027a4cb5c8326b08b603ae1464f06