### PR TITLE
CI: gate glossary scoring to new slugs

### DIFF
--- a/.github/workflows/pr-complete.yml
+++ b/.github/workflows/pr-complete.yml
@@ -22,18 +22,105 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Need full history for diff
+          ref: ${{ github.event.pull_request.head.sha }}
       
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
           node-version: '20'
-      
+
       - name: Install dependencies
         run: npm ci --include=dev --no-audit --no-fund
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.event.pull_request.base.ref }} --depth=1
+
+      - name: Detect glossary changes
+        id: glossary
+        run: |
+          BASE_REF="${{ github.event.pull_request.base.ref }}"
+          {
+            echo 'terms_changed=false'
+            echo 'has_new_slugs=false'
+            echo 'new_slug_count=0'
+            echo 'primary_slug='
+            echo 'new_slugs='
+          } >> "$GITHUB_OUTPUT"
+
+          node - <<'NODE'
+          const fs = require('fs');
+          const yaml = require('js-yaml');
+          const { execSync } = require('child_process');
+
+          const baseRef = process.env.BASE_REF;
+          const outputPath = process.env.GITHUB_OUTPUT;
+
+          function writeOutput(key, value) {
+            fs.appendFileSync(outputPath, `\n${key}=${value}`);
+          }
+
+          let headContent = '';
+          try {
+            headContent = fs.readFileSync('terms.yaml', 'utf8');
+          } catch (error) {
+            console.error('Unable to read terms.yaml from head commit.');
+            process.exit(1);
+          }
+
+          let baseContent = '';
+          try {
+            baseContent = execSync(`git show origin/${baseRef}:terms.yaml`, { encoding: 'utf8' });
+          } catch (error) {
+            // If the file does not exist on the base branch (e.g., first contribution), treat as empty.
+            baseContent = '';
+          }
+
+          const termsChanged = headContent.trim() !== baseContent.trim();
+          writeOutput('terms_changed', termsChanged);
+
+          if (!termsChanged) {
+            return;
+          }
+
+          let baseTerms = [];
+          let headTerms = [];
+
+          try {
+            if (baseContent.trim()) {
+              const parsedBase = yaml.load(baseContent);
+              if (parsedBase && Array.isArray(parsedBase.terms)) {
+                baseTerms = parsedBase.terms;
+              }
+            }
+          } catch (error) {
+            console.warn('Unable to parse base terms.yaml:', error.message);
+          }
+
+          try {
+            const parsedHead = yaml.load(headContent);
+            if (parsedHead && Array.isArray(parsedHead.terms)) {
+              headTerms = parsedHead.terms;
+            }
+          } catch (error) {
+            console.error('Unable to parse head terms.yaml:', error.message);
+            process.exit(1);
+          }
+
+          const baseSlugs = new Set((baseTerms || []).map(term => term && term.slug).filter(Boolean));
+          const newSlugs = (headTerms || [])
+            .map(term => term && term.slug)
+            .filter(slug => slug && !baseSlugs.has(slug));
+
+          writeOutput('has_new_slugs', newSlugs.length > 0);
+          writeOutput('new_slug_count', newSlugs.length);
+          writeOutput('primary_slug', newSlugs.length > 0 ? newSlugs[newSlugs.length - 1] : '');
+          writeOutput('new_slugs', newSlugs.join(','));
+          NODE
       
       # Step 1: Validate the YAML
       - name: Validate terms
         id: validate
+        if: steps.glossary.outputs.terms_changed == 'true'
         #continue-on-error: true
         run: |
           node scripts/validateTerms.js 2>&1 | tee validation-output.txt
@@ -49,13 +136,13 @@ jobs:
       # Step 2: Score if valid
       - name: Score terms
         id: score
-        if: steps.validate.outputs.valid == '0'
+        if: steps.validate.outputs.valid == '0' && steps.glossary.outputs.has_new_slugs == 'true'
         run: |
-          node scripts/quickScore.js > score-output.txt
+          TARGET_SLUG=${{ steps.glossary.outputs.primary_slug }} node scripts/quickScore.js > score-output.txt
           cat score-output.txt
           echo "score=$(grep 'SCORE:' score-output.txt | cut -d: -f2)" >> $GITHUB_OUTPUT
           echo "badge=$(grep 'BADGE:' score-output.txt | cut -d: -f2-)" >> $GITHUB_OUTPUT
-      
+
       # Step 3: Get PR statistics
       - name: Get glossary stats
         id: stats
@@ -91,17 +178,7 @@ jobs:
             console.log('high_score=' + highScore);
             console.log('top_scorer=' + topScorer);
             
-            // Get the diff to find new terms
-            const { execSync } = require('child_process');
-            try {
-              const diff = execSync('git diff origin/main...HEAD -- terms.yaml', { encoding: 'utf8' });
-              const newTermMatch = diff.match(/\+\s*- term: \"([^\"]+)\"/);
-              if (newTermMatch) {
-                console.log('new_term=' + newTermMatch[1]);
-              }
-            } catch (e) {
-              console.log('new_term=Unknown');
-            }
+            console.log('new_term=Unknown');
           } catch (error) {
             console.log('total_terms=0');
             console.log('high_score=0');
@@ -120,6 +197,11 @@ jobs:
           github-token: ${{ github.token }}
           script: |
             // Get all our data
+            const termsChanged = '${{ steps.glossary.outputs.terms_changed }}' === 'true';
+            const hasNewSlugs = '${{ steps.glossary.outputs.has_new_slugs }}' === 'true';
+            const newSlugList = '${{ steps.glossary.outputs.new_slugs }}';
+            const primarySlug = '${{ steps.glossary.outputs.primary_slug }}';
+            const newSlugCountRaw = '${{ steps.glossary.outputs.new_slug_count }}';
             const isValid = '${{ steps.validate.outputs.valid }}' === '0';
             const validationOutput = `${{ steps.validate.outputs.validation_output }}`;
             const score = '${{ steps.score.outputs.score }}' || '0';
@@ -127,19 +209,24 @@ jobs:
             const totalTerms = '${{ steps.stats.outputs.total_terms }}' || '0';
             const highScore = '${{ steps.stats.outputs.high_score }}' || '0';
             const topScorer = '${{ steps.stats.outputs.top_scorer }}' || 'None';
-            const newTerm = '${{ steps.stats.outputs.new_term }}' || 'Unknown';
-            
+            const newTerm = primarySlug || 'Unknown';
+            const newSlugCount = parseInt(newSlugCountRaw || '0', 10) || 0;
+
             let comment = '';
-            
+
             // Title based on whether it's first comment or update
             const isFirstRun = context.payload.action === 'opened';
-            
-            if (!isValid) {
+
+            if (!termsChanged) {
+              comment = `## ℹ️ No glossary changes detected\n\n`;
+              comment += `terms.yaml is unchanged in the latest commit. Validation and scoring were skipped.\n\n`;
+              comment += `I'll keep watching for glossary updates on future pushes. 🤖`;
+            } else if (!isValid) {
               // VALIDATION FAILED
               comment = `## ❌ Validation Failed!\n\n`;
               comment += `### The Issue:\n`;
               comment += '```\n' + validationOutput.replace(/✅.*\n/g, '').trim() + '\n```\n\n';
-              
+
               comment += `### 🔧 How to Fix:\n`;
               comment += `1. Check your YAML indentation (use 2 spaces, not tabs)\n`;
               comment += `2. Make sure you have both \`term\` and \`definition\` fields\n`;
@@ -159,66 +246,77 @@ jobs:
             } else {
               // VALIDATION PASSED - Show score
               comment = `## ✅ Validation Passed!\n\n`;
-              
-              if (newTerm !== 'Unknown') {
-                comment += `### 📝 New Term: "${newTerm}"\n\n`;
-              }
-              
-              comment += `### 📊 Your Score: ${score}/100\n\n`;
-              
-              // Score tier message
-              if (score >= 90) {
-                comment += `# 🏆 LEGENDARY CONTRIBUTION!\n`;
-                comment += `You've achieved excellence! This is Hall of Fame material! 🌟\n\n`;
-              } else if (score >= 80) {
-                comment += `## 🔥 AMAZING!\n`;
-                comment += `Outstanding work! You're in the top tier! 💪\n\n`;
-              } else if (score >= 70) {
-                comment += `### 💪 Great Job!\n`;
-                comment += `Solid contribution! Well above average! 👏\n\n`;
-              } else if (score >= 60) {
-                comment += `### 👍 Good Work!\n`;
-                comment += `Nice contribution! Consider adding more details for bonus points!\n\n`;
-              } else {
-                comment += `### 🌱 Good Start!\n`;
-                comment += `Thanks for contributing! Here's how to boost your score:\n\n`;
-              }
-              
-              // Achievements
-              if (badge) {
-                comment += `### 🏅 Achievements Unlocked:\n`;
-                badge.split(',').forEach(b => {
-                  const trimmed = b.trim();
-                  if (trimmed) comment += `- ${trimmed}\n`;
-                });
-                comment += '\n';
-              }
-              
-              // Improvement tips for lower scores
-              if (score < 80) {
-                comment += `### 💡 Quick Tips to Improve:\n`;
-                if (!badge.includes('Comedy Gold')) {
-                  comment += `- Add more humor (current max: 30 points)\n`;
+
+              if (hasNewSlugs && newSlugCount > 0) {
+                if (newSlugCount === 1) {
+                  comment += `### 📝 New Term: "${newTerm}"\n\n`;
+                } else {
+                  const slugDisplay = newSlugList.split(',').filter(Boolean).map(slug => `"${slug}"`).join(', ');
+                  comment += `### 📝 New Terms (${newSlugCount}): ${slugDisplay}\n\n`;
                 }
-                comment += `- Add an \`explanation\` field (+20 points)\n`;
-                comment += `- Include \`see_also\` references (+20 points)\n`;
-                comment += `- Add relevant \`tags\` (+10 points)\n\n`;
-              }
-              
-              // Leaderboard section
-              comment += `### 🏆 Current Leaderboard\n`;
-              comment += `- **Your Score:** ${score}/100\n`;
-              comment += `- **High Score:** ${highScore}/100 (${topScorer})\n`;
-              comment += `- **Total Terms:** ${totalTerms}\n\n`;
-              
-              // Comparison
-              if (parseInt(score) >= parseInt(highScore)) {
-                comment += `**🎊 NEW HIGH SCORE! You're the champion!** 🎊\n\n`;
+
+                comment += `### 📊 Your Score: ${score}/100\n\n`;
+
+                // Score tier message
+                if (score >= 90) {
+                  comment += `# 🏆 LEGENDARY CONTRIBUTION!\n`;
+                  comment += `You've achieved excellence! This is Hall of Fame material! 🌟\n\n`;
+                } else if (score >= 80) {
+                  comment += `## 🔥 AMAZING!\n`;
+                  comment += `Outstanding work! You're in the top tier! 💪\n\n`;
+                } else if (score >= 70) {
+                  comment += `### 💪 Great Job!\n`;
+                  comment += `Solid contribution! Well above average! 👏\n\n`;
+                } else if (score >= 60) {
+                  comment += `### 👍 Good Work!\n`;
+                  comment += `Nice contribution! Consider adding more details for bonus points!\n\n`;
+                } else {
+                  comment += `### 🌱 Good Start!\n`;
+                  comment += `Thanks for contributing! Here's how to boost your score:\n\n`;
+                }
+
+                // Achievements
+                if (badge) {
+                  comment += `### 🏅 Achievements Unlocked:\n`;
+                  badge.split(',').forEach(b => {
+                    const trimmed = b.trim();
+                    if (trimmed) comment += `- ${trimmed}\n`;
+                  });
+                  comment += '\n';
+                }
+
+                // Improvement tips for lower scores
+                if (score < 80) {
+                  comment += `### 💡 Quick Tips to Improve:\n`;
+                  if (!badge.includes('Comedy Gold')) {
+                    comment += `- Add more humor (current max: 30 points)\n`;
+                  }
+                  comment += `- Add an \`explanation\` field (+20 points)\n`;
+                  comment += `- Include \`see_also\` references (+20 points)\n`;
+                  comment += `- Add relevant \`tags\` (+10 points)\n\n`;
+                }
+
+                // Leaderboard section
+                comment += `### 🏆 Current Leaderboard\n`;
+                comment += `- **Your Score:** ${score}/100\n`;
+                comment += `- **High Score:** ${highScore}/100 (${topScorer})\n`;
+                comment += `- **Total Terms:** ${totalTerms}\n\n`;
+
+                // Comparison
+                if (parseInt(score) >= parseInt(highScore)) {
+                  comment += `**🎊 NEW HIGH SCORE! You're the champion!** 🎊\n\n`;
+                } else {
+                  const diff = parseInt(highScore) - parseInt(score);
+                  comment += `You're ${diff} points away from the high score! ${diff <= 10 ? 'So close! 🔥' : 'Keep pushing! 💪'}\n\n`;
+                }
               } else {
-                const diff = parseInt(highScore) - parseInt(score);
-                comment += `You're ${diff} points away from the high score! ${diff <= 10 ? 'So close! 🔥' : 'Keep pushing! 💪'}\n\n`;
+                comment += `### 📋 Summary\n`;
+                comment += `- No brand-new slugs detected in this update.\n`;
+                comment += `- Validation succeeded for the existing glossary entries.\n\n`;
+                comment += `Scoring only runs for newly added slugs per the PR gating rules. ✅\n\n`;
+                comment += `Total terms in the glossary: ${totalTerms}.\n\n`;
               }
-              
+
               comment += `---\n`;
               comment += `*Ready for merge after maintainer review!* ✨`;
             }

--- a/scripts/quickScore.js
+++ b/scripts/quickScore.js
@@ -62,41 +62,52 @@ function main() {
   try {
     // Read the terms file
     const termsData = yaml.load(fs.readFileSync('terms.yaml', 'utf8'));
-    
+
     if (!termsData || !termsData.terms || !Array.isArray(termsData.terms)) {
       console.error('Error: Invalid terms.yaml structure');
       process.exit(1);
     }
-    
-    // Get the latest term (assuming it's the last one added)
-    const latestTerm = termsData.terms[termsData.terms.length - 1];
-    
-    if (!latestTerm) {
+
+    const targetSlug = process.env.TARGET_SLUG;
+    let termToScore = null;
+
+    if (targetSlug) {
+      termToScore = termsData.terms.find(term => term && term.slug === targetSlug);
+      if (!termToScore) {
+        console.error(`Error: No term found with slug "${targetSlug}".`);
+        process.exit(1);
+      }
+    } else {
+      // Get the latest term (assuming it's the last one added)
+      termToScore = termsData.terms[termsData.terms.length - 1];
+    }
+
+    if (!termToScore) {
       console.error('Error: No terms found');
       process.exit(1);
     }
-    
+
     // Score the term
-    const { score, badges } = scoreTerm(latestTerm);
-    
+    const { score, badges } = scoreTerm(termToScore);
+
     // Output for GitHub Actions
-    console.log(`\n📊 Scoring Results for "${latestTerm.term}":\n`);
+    console.log(`\n📊 Scoring Results for "${termToScore.term}":\n`);
     console.log(`SCORE:${score}`);
-    
+
     if (badges.length > 0) {
       console.log(`BADGE:${badges.join(', ')}`);
     }
-    
+
     // Detailed breakdown
     console.log('\n📋 Score Breakdown:');
-    console.log(`- Base definition: ${latestTerm.term && latestTerm.definition ? '20/20' : '0/20'}`);
-    console.log(`- Humor: ${latestTerm.humor ? Math.min(30, Math.floor(latestTerm.humor.length / 5)) : '0'}/30`);
-    console.log(`- Explanation: ${latestTerm.explanation ? '20/20' : '0/20'}`);
-    console.log(`- Tags: ${latestTerm.tags ? Math.min(10, latestTerm.tags.length * 3) : '0'}/10`);
-    console.log(`- Cross-references: ${latestTerm.see_also ? Math.min(20, latestTerm.see_also.length * 5) : '0'}/20`);
-    
+    console.log(`- Base definition: ${termToScore.term && termToScore.definition ? '20/20' : '0/20'}`);
+    console.log(`- Humor: ${termToScore.humor ? Math.min(30, Math.floor(termToScore.humor.length / 5)) : '0'}/30`);
+    console.log(`- Explanation: ${termToScore.explanation ? '20/20' : '0/20'}`);
+    console.log(`- Tags: ${termToScore.tags ? Math.min(10, termToScore.tags.length * 3) : '0'}/10`);
+    console.log(`- Cross-references: ${termToScore.see_also ? Math.min(20, termToScore.see_also.length * 5) : '0'}/20`);
+
     console.log(`\nTotal: ${score}/100`);
-    
+
     if (score >= 90) {
       console.log('\n🎉 OUTSTANDING! This is a legendary contribution!');
     } else if (score >= 80) {


### PR DESCRIPTION
## Summary
- detect whether `terms.yaml` changed and whether any new slugs were introduced before running validation/scoring logic.
- target `quickScore` at the latest new slug and update the PR comment to explain when scoring is skipped.

## Files Modified
- .github/workflows/pr-complete.yml
- scripts/quickScore.js

## Acceptance Criteria
- [x] Validation step only executes when `terms.yaml` differs from the base branch.
- [x] Scoring runs exclusively for newly added slugs and uses the matching slug when computing the score.
- [x] Bot comment clarifies when scoring is skipped because no new slugs were detected.

## Negative Test Plan
- Validate that a PR with no `terms.yaml` delta would skip validation and scoring while posting an informational comment.
- Validate that a PR which edits existing terms without new slugs still passes validation but reports that scoring was skipped.


------
https://chatgpt.com/codex/tasks/task_e_68f118575a948326a77cb433f1d5a3bc