### PR TITLE
Automate Codex bot issue intake

### DIFF
--- a/.github/workflows/issue-assigned-codex.yml
+++ b/.github/workflows/issue-assigned-codex.yml
@@ -1,67 +1,88 @@
-name: On issue assigned to Codex bot
+name: Codex issue intake
 
 on:
   issues:
-    types: [assigned]
+    types: [assigned, labeled]
 
 permissions:
-  issues: write
-  pull-requests: write
   contents: read
-  actions: read
+  issues: write
+  pull-requests: read
 
 env:
-  ACK_LABEL: in-progress   # label to apply; safe default
+  ACK_LABEL: in-progress
+  CODEX_LABEL: codex
 
 jobs:
   acknowledge:
-    # NOTE: job-level 'if' cannot use env.* — use vars.* + constants here.
-    if: >
-      github.event_name == 'issues' &&
-      github.event.action == 'assigned' &&
-      (
-        (vars.CODEX_BOT_LOGIN != '' && github.event.assignee.login == vars.CODEX_BOT_LOGIN) ||
-        (vars.CODEX_BOT_LOGIN == '' && github.event.assignee.login == 'codex-bot')
-      )
+    if: github.event.issue.state == 'open'
     runs-on: ubuntu-latest
     steps:
-      - name: Acknowledge & label
+      - name: Acknowledge assignment as Codex bot
         uses: actions/github-script@v7
-        env:
-          # Pass the variable into the step as env so the script can read it
-          CODEX_BOT_LOGIN: ${{ vars.CODEX_BOT_LOGIN }}
-          ACK_LABEL: ${{ env.ACK_LABEL }}
         with:
+          github-token: ${{ secrets.CODEX_FOSS_TOK != '' && secrets.CODEX_FOSS_TOK || secrets.GITHUB_TOKEN }}
           script: |
+            const marker = '<!-- codex-acknowledged -->';
+            const ackLabel = (process.env.ACK_LABEL || '').trim();
+            const codexLabel = (process.env.CODEX_LABEL || 'codex').toLowerCase();
+            const botLogin = (process.env.CODEX_BOT_LOGIN || 'my-codex-bot').toLowerCase();
+
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
+            const issue = context.payload.issue;
 
-            const bot = process.env.CODEX_BOT_LOGIN || 'codex-bot';
-            const ackLabel = process.env.ACK_LABEL || 'in-progress';
+            const assignees = issue.assignees || [];
+            const labels = issue.labels || [];
 
-            // 1) Acknowledge
-            await github.rest.issues.createComment({
-              owner, repo, issue_number,
-              body: `👋 @${bot} subscribed. Starting work.\n\nIf more details are needed, I'll ask here.`
-            });
+            const assignedToBot = assignees.some(a => (a.login || '').toLowerCase() === botLogin);
+            if (!assignedToBot) {
+              core.info(`Issue #${issue_number} is not assigned to ${botLogin}. Skipping.`);
+              return;
+            }
 
-            // 2) Add/create label
-            try {
-              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [ackLabel] });
-            } catch (e) {
-              if (e.status === 404) {
-                await github.rest.issues.createLabel({
-                  owner, repo, name: ackLabel, color: '0E8A16',
-                  description: 'Issue is being handled by the bot'
-                }).catch(() => {});
+            const hasCodexLabel = labels.some(l => (l.name || '').toLowerCase() === codexLabel);
+            if (!hasCodexLabel) {
+              core.info(`Issue #${issue_number} is missing the required "${codexLabel}" label. Skipping.`);
+              return;
+            }
+
+            const ackBody = `${marker}\n👋 Thanks for the assignment! @${issue.user.login} Codex is on it.\n\nI'll follow up here with questions or a pull request update once work begins.\n\n_This acknowledgement was posted automatically._`;
+
+            const existingComments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number });
+            const alreadyAcknowledged = existingComments.some(comment => (comment.body || '').includes(marker));
+
+            if (!alreadyAcknowledged) {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body: ackBody });
+              core.info(`Posted acknowledgement on issue #${issue_number} as ${botLogin}.`);
+            } else {
+              core.info(`Issue #${issue_number} was already acknowledged. Skipping comment.`);
+            }
+
+            if (ackLabel && ackLabel.toLowerCase() !== codexLabel) {
+              try {
                 await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [ackLabel] });
-              } else {
-                throw e;
+                core.info(`Applied label "${ackLabel}" to issue #${issue_number}.`);
+              } catch (error) {
+                if (error.status === 404) {
+                  core.info(`Label "${ackLabel}" not found. Creating it before applying.`);
+                  await github.rest.issues.createLabel({
+                    owner,
+                    repo,
+                    name: ackLabel,
+                    color: '0E8A16',
+                    description: 'Issue is being handled by Codex bot',
+                  }).catch(() => core.info(`Label "${ackLabel}" may already exist. Continuing.`));
+                  await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [ackLabel] });
+                } else {
+                  throw error;
+                }
               }
             }
 
-            // 3) Job summary
-            core.summary
-              .addHeading('Codex bot acknowledged')
-              .addRaw(`Issue #${issue_number} labeled **${ackLabel}** and acknowledged by **@${bot}**.`)
+            await core.summary
+              .addHeading('Codex bot acknowledgement complete')
+              .addRaw(`Issue #${issue_number} assigned to **@${botLogin}** acknowledged successfully.`)
               .write();
+        env:
+          CODEX_BOT_LOGIN: ${{ vars.CODEX_BOT_LOGIN }}

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ A community-driven glossary of FOSS terms with humor, sarcasm, and honest truths
 4. Get your quality score (try to beat 80/100!)
 5. Earn achievements! 🏆
 
+## 🤖 Codex Issue Automation
+
+Issues labeled `codex` and assigned to the bot account are acknowledged automatically:
+
+1. Store the Fine-Grained PAT for `my-codex-bot` in a repository secret named `CODEX_FOSS_TOK`.
+2. (Optional) Create a repository variable `CODEX_BOT_LOGIN` if you need to override the default bot login.
+3. Assign the issue to `my-codex-bot` and apply the `codex` label. The workflow will comment as the bot and add the `in-progress` label when it picks up the task.
+
 ## 📊 Scoring System
 
 Every term is scored out of 100 points:


### PR DESCRIPTION
## Summary
- update the issue intake workflow to acknowledge codex-labeled assignments with the my-codex-bot account
- ensure duplicate comments are avoided, create the in-progress label when missing, and fall back to the default token when needed
- document the required secret/variable setup for the automation in the README

## Files Modified
- .github/workflows/issue-assigned-codex.yml
- README.md

## Checklist
- [x] Comment only posts when the issue is assigned to the bot and carries the `codex` label
- [x] Workflow falls back to the default `GITHUB_TOKEN` if the fine-grained PAT is not configured
- [x] Documentation explains how to configure the secret and optional repository variable

## Negative Test Plan
- Reviewed the workflow logic paths to confirm it aborts when the label or assignee prerequisites are not met

Fixes #<ISSUE_NUMBER>


------
https://chatgpt.com/codex/tasks/task_e_68f2777ff6388326b3aa726afb757c83