### PR TITLE
Potential fix for code scanning alert no. 2: Shell command built from environment values

### DIFF
--- a/tests/sortYaml.test.js
+++ b/tests/sortYaml.test.js
@@ -3,7 +3,7 @@ const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 
 const SCRIPT_PATH = path.join(__dirname, '..', 'scripts', 'sortYaml.js');
 
@@ -70,7 +70,7 @@ test('sortYaml: check mode detects unsorted terms', () => {
 
   try {
     // Run check mode - should fail
-    execSync(`node ${SCRIPT_PATH} --check`, { cwd: tmpDir, encoding: 'utf8' });
+    execFileSync('node', [SCRIPT_PATH, '--check'], { cwd: tmpDir, encoding: 'utf8' });
     assert.fail('Check mode should have failed for unsorted terms');
   } catch (error) {
     assert.strictEqual(error.status, 1, 'Should exit with code 1');


### PR DESCRIPTION
Potential fix for [https://github.com/LuminLynx/FOSS-Glossary/security/code-scanning/2](https://github.com/LuminLynx/FOSS-Glossary/security/code-scanning/2)

To fix the vulnerability, we should avoid constructing a shell command string with interpolated environment or file system values. Instead, use `execFileSync` or `execSync` with an arguments array. Specifically, on line 73, instead of 

```js
execSync(`node ${SCRIPT_PATH} --check`, { cwd: tmpDir, encoding: 'utf8' });
```

we should run the child process as `node <SCRIPT_PATH> --check` by providing `node` as the command and the arguments as an array: `[SCRIPT_PATH, '--check']` with `execFileSync`. This way, the values are properly escaped, and there is no risk of unexpected shell interpretation of the values.

Since `execSync` runs a shell command (via `/bin/sh -c`, subject to interpolation issues), we should switch to `execFileSync`, which does not do shell parsing. Since `execFileSync` is already used elsewhere in the file, and is imported as necessary, we just need to change the test on line 73 to use `execFileSync`.

Required steps:
- Import `execFileSync` if not already imported.
- Change the test on line 73 to use `execFileSync` with an arguments array.
- No other changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
