### PR TITLE
Potential fix for code scanning alert no. 3: Shell command built from environment values

### DIFF
--- a/tests/sortYaml.test.js
+++ b/tests/sortYaml.test.js
@@ -101,7 +101,7 @@ test('sortYaml: check mode passes for sorted terms', () => {
   fs.writeFileSync(termsFile, sorted, 'utf8');
 
   try {
-    const output = execSync(`node ${SCRIPT_PATH} --check`, {
+    const output = execFileSync('node', [SCRIPT_PATH, '--check'], {
       cwd: tmpDir,
       encoding: 'utf8',
     });


### PR DESCRIPTION
Potential fix for [https://github.com/LuminLynx/FOSS-Glossary/security/code-scanning/3](https://github.com/LuminLynx/FOSS-Glossary/security/code-scanning/3)

The issue arises because the shell command on line 104 is constructed as a single string using interpolated values (specifically, the absolute path determined by `SCRIPT_PATH`), which could contain spaces or special shell characters and is passed to `execSync`. This can cause shell interpretation issues or vulnerabilities if the path is not properly escaped.

**The single best fix** is to use `execFileSync` instead of `execSync` for running the "node" process. Instead of constructing a single shell command string, call `execFileSync('node', [SCRIPT_PATH, '--check'], { ... })`, with the script path and any further arguments supplied as separate entries in an array. This ensures all values are treated as literal arguments by the process, not as shell-interpreted strings.  

**Specific steps:**
- Find the block at line 104: `const output = execSync(\`node ${SCRIPT_PATH} --check\`, { ... });`
- Replace this with:  
  `const output = execFileSync('node', [SCRIPT_PATH, '--check'], { ... });`
- Make sure the rest of the test logic is unchanged.
- No additional imports are needed as `execFileSync` is already imported at line 6.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
