### PR TITLE
Potential fix for code scanning alert no. 4: Shell command built from environment values

### DIFF
--- a/tests/sortYaml.test.js
+++ b/tests/sortYaml.test.js
@@ -129,7 +129,7 @@ terms:
   fs.writeFileSync(termsFile, withHeader, 'utf8');
 
   try {
-    execSync(`node ${SCRIPT_PATH}`, { cwd: tmpDir, encoding: 'utf8' });
+    execFileSync('node', [SCRIPT_PATH], { cwd: tmpDir, encoding: 'utf8' });
     const sorted = fs.readFileSync(termsFile, 'utf8');
     assert.ok(sorted.startsWith('# FOSS Glossary'), 'Header comment should be preserved');
   } finally {


### PR DESCRIPTION
Potential fix for [https://github.com/LuminLynx/FOSS-Glossary/security/code-scanning/4](https://github.com/LuminLynx/FOSS-Glossary/security/code-scanning/4)

**How to fix the problem (general):**  
Avoid constructing shell commands by concatenating or interpolating values like file paths, and instead use `execFileSync` or `execFile` with argument arrays to avoid shell parsing of special characters.

**Single best fix (detailed):**  
Change the use of `execSync(`node ${SCRIPT_PATH}`, ...)` in line 132 to use `execFileSync('node', [SCRIPT_PATH], ...)`. This avoids the shell entirely, protecting against whitespace and other special characters in the path. As `execFileSync` returns a buffer by default, and this call does not need to capture output (just run the script and expect it to modify the file), the usage is fine. The arguments and options (cwd, encoding, etc.) should remain unchanged.

**Files/lines to change:**  
- File: `tests/sortYaml.test.js`, line 132: Change `execSync` with template string to `execFileSync` with argument array.

**What is needed:**  
- No new imports are required (`execFileSync` is already imported on line 6).
- Just replace the problematic call.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
