### PR TITLE
Potential fix for code scanning alert no. 4: Shell command built from environment values

### DIFF
--- a/tests/sortYaml.test.js
+++ b/tests/sortYaml.test.js
@@ -153,7 +153,7 @@ test('sortYaml: handles strings with apostrophes correctly', () => {
   fs.writeFileSync(termsFile, withApostrophe, 'utf8');
 
   try {
-    execSync(`node ${SCRIPT_PATH}`, { cwd: tmpDir, encoding: 'utf8' });
+    execFileSync('node', [SCRIPT_PATH], { cwd: tmpDir, encoding: 'utf8' });
     const sorted = fs.readFileSync(termsFile, 'utf8');
     // Should preserve apostrophes correctly (js-yaml handles quote escaping automatically)
     assert.ok(sorted.includes("doesn't"), 'Should preserve apostrophes correctly');


### PR DESCRIPTION
Potential fix for [https://github.com/LuminLynx/FOSS-Glossary/security/code-scanning/4](https://github.com/LuminLynx/FOSS-Glossary/security/code-scanning/4)

To fix this issue, replace the use of `execSync` on line 156 with `execFileSync`, passing `'node'` as the command and `[SCRIPT_PATH]` as the argument array. This means the file path will be interpreted as a literal argument and not parsed by the shell, thus removing any possibility of special characters affecting execution. The cwd, encoding, and other options can be preserved as before. No changes to imports or logic are required, as `execFileSync` is already imported at the top. Only the relevant code in this file needs to change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
