### PR TITLE
Potential fix for code scanning alert no. 4: Shell command built from environment values

### DIFF
--- a/tests/sortYaml.test.js
+++ b/tests/sortYaml.test.js
@@ -183,7 +183,7 @@ test('sortYaml: normalizes key order within terms', () => {
   fs.writeFileSync(termsFile, unsortedKeys, 'utf8');
 
   try {
-    execSync(`node ${SCRIPT_PATH}`, { cwd: tmpDir, encoding: 'utf8' });
+    execFileSync('node', [SCRIPT_PATH], { cwd: tmpDir, encoding: 'utf8' });
     const sorted = fs.readFileSync(termsFile, 'utf8');
 
     // Verify canonical key order: slug, term, definition, explanation, humor, see_also, tags, aliases, controversy_level


### PR DESCRIPTION
Potential fix for [https://github.com/LuminLynx/FOSS-Glossary/security/code-scanning/4](https://github.com/LuminLynx/FOSS-Glossary/security/code-scanning/4)

The best fix is to avoid constructing a string command that is interpreted by a shell. Instead of using `execSync(\`node ${SCRIPT_PATH}\`, ...)`, switch to using `execFileSync('node', [SCRIPT_PATH], ...)`, just as the other test on line 31 already does. This passes the command and arguments directly, entirely bypassing the shell and preventing shell interpretation of any special characters in the path. Only line 186 needs to be changed this way; supporting imports are already present.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
